### PR TITLE
Add Store page with product catalog management

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -11,6 +11,7 @@ import Finance from "./pages/Finance";
 import CustomerService from "./pages/CustomerService";
 import NotFound from "./pages/NotFound";
 import Login from "./pages/Login";
+import Store from "./pages/Store";
 
 const queryClient = new QueryClient();
 

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -27,6 +27,7 @@ const App = () => (
           <Route path="/stock" element={<Stock />} />
           <Route path="/finance" element={<Finance />} />
           <Route path="/customer-service" element={<CustomerService />} />
+          <Route path="/store" element={<Store />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -62,6 +62,7 @@ function NavItems() {
     { to: "/overview", label: "Overview", icon: Home },
     { to: "/stock", label: "Stock", icon: PackageSearch },
     { to: "/finance", label: "Finance", icon: PiggyBank },
+    { to: "/store", label: "Store", icon: ShoppingCart },
     { to: "/customer-service", label: "Customer Service", icon: Headphones },
   ];
 

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -23,6 +23,7 @@ import {
   PackageSearch,
   PiggyBank,
   Headphones,
+  ShoppingCart,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/client/pages/Store.tsx
+++ b/client/pages/Store.tsx
@@ -293,7 +293,7 @@ export default function Store() {
                   <TableHead>Price</TableHead>
                   <TableHead>Stock</TableHead>
                   <TableHead>Added</TableHead>
-                  <TableHead className="text-right">Action</TableHead>
+                  <TableHead className="text-right w-28">Action</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -321,41 +321,43 @@ export default function Store() {
                     <TableCell>${p.price.toFixed(2)}</TableCell>
                     <TableCell>{p.stock}</TableCell>
                     <TableCell>{new Date(p.addedAt).toLocaleDateString()}</TableCell>
-                    <TableCell className="text-right space-x-1">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => {
-                          setEditingId(p.id);
-                          form.reset({
-                            name: p.name,
-                            category: p.category,
-                            unit: p.unit ?? "g",
-                            size: p.size ?? "",
-                            price: p.price,
-                            sku: p.sku,
-                            stock: p.stock,
-                            imageUrl: p.imageUrl ?? "",
-                            description: p.description ?? "",
-                          });
-                        }}
-                        aria-label={`Edit ${p.name}`}
-                      >
-                        <Pencil />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-destructive"
-                        onClick={() => {
-                          setItems((prev) => prev.filter((it) => it.id !== p.id));
-                          if (editingId === p.id) { setEditingId(null); form.reset(); }
-                          toast({ title: "Deleted", description: `${p.name} removed from catalog.` });
-                        }}
-                        aria-label={`Delete ${p.name}`}
-                      >
-                        <Trash2 />
-                      </Button>
+                    <TableCell className="text-right whitespace-nowrap">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => {
+                            setEditingId(p.id);
+                            form.reset({
+                              name: p.name,
+                              category: p.category,
+                              unit: p.unit ?? "g",
+                              size: p.size ?? "",
+                              price: p.price,
+                              sku: p.sku,
+                              stock: p.stock,
+                              imageUrl: p.imageUrl ?? "",
+                              description: p.description ?? "",
+                            });
+                          }}
+                          aria-label={`Edit ${p.name}`}
+                        >
+                          <Pencil />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-destructive"
+                          onClick={() => {
+                            setItems((prev) => prev.filter((it) => it.id !== p.id));
+                            if (editingId === p.id) { setEditingId(null); form.reset(); }
+                            toast({ title: "Deleted", description: `${p.name} removed from catalog.` });
+                          }}
+                          aria-label={`Delete ${p.name}`}
+                        >
+                          <Trash2 />
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/client/pages/Store.tsx
+++ b/client/pages/Store.tsx
@@ -31,7 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "@/hooks/use-toast";
-import { Trash2 } from "lucide-react";
+import { Trash2, Image as ImageIcon } from "lucide-react";
 
 const productSchema = z.object({
   name: z.string().min(2, "Enter a product name"),
@@ -96,7 +96,7 @@ export default function Store() {
   const onSubmit = (values: ProductInput) => {
     const product: Product = {
       ...values,
-      imageUrl: values.imageUrl && values.imageUrl.trim() !== "" ? values.imageUrl : "/placeholder.svg",
+      imageUrl: (values.imageUrl ?? "").trim(),
       id: uid(),
       addedAt: new Date().toISOString(),
     };
@@ -268,6 +268,7 @@ export default function Store() {
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead>Img</TableHead>
                   <TableHead>Product</TableHead>
                   <TableHead>Category</TableHead>
                   <TableHead>SKU</TableHead>
@@ -281,8 +282,15 @@ export default function Store() {
               <TableBody>
                 {items.map((p) => (
                   <TableRow key={p.id}>
+                    <TableCell>
+                      {p.imageUrl ? (
+                        <ImageIcon className="text-primary" />
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
                     <TableCell className="flex items-center gap-3">
-                      <img src={p.imageUrl} alt="" className="size-10 rounded-md object-cover border" />
+                      <img src={p.imageUrl || "/placeholder.svg"} alt="" className="size-10 rounded-md object-cover border" />
                       <div>
                         <div className="font-medium leading-tight">{p.name}</div>
                         {p.description && (

--- a/client/pages/Store.tsx
+++ b/client/pages/Store.tsx
@@ -41,11 +41,7 @@ const productSchema = z.object({
   price: z.coerce.number().min(0, "Price must be >= 0"),
   sku: z.string().min(1, "SKU is required"),
   stock: z.coerce.number().int().min(0, "Stock must be >= 0"),
-  imageUrl: z
-    .string()
-    .url({ message: "Must be a valid URL" })
-    .optional()
-    .or(z.literal("")),
+  imageUrl: z.string().optional().or(z.literal("")),
   description: z.string().max(500).optional().or(z.literal("")),
 });
 
@@ -177,10 +173,31 @@ export default function Store() {
                   )}
                 </div>
                 <div className="grid gap-3">
-                  <Label htmlFor="imageUrl">Image URL</Label>
-                  <Input id="imageUrl" placeholder="https://..." {...form.register("imageUrl")} />
-                  {form.formState.errors.imageUrl && (
-                    <p className="text-sm text-destructive">{form.formState.errors.imageUrl.message}</p>
+                  <Label htmlFor="image">Image</Label>
+                  <Input
+                    id="image"
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      if (file.size > 3 * 1024 * 1024) {
+                        toast({ title: "Image too large", description: "Max size is 3MB" });
+                        return;
+                      }
+                      const reader = new FileReader();
+                      reader.onload = () => {
+                        const url = String(reader.result ?? "");
+                        form.setValue("imageUrl", url, { shouldDirty: true });
+                      };
+                      reader.readAsDataURL(file);
+                    }}
+                  />
+                  {form.watch("imageUrl") && (
+                    <div className="flex items-center gap-3">
+                      <img src={form.watch("imageUrl")!} alt="preview" className="size-12 rounded-md object-cover border" />
+                      <Button type="button" variant="ghost" onClick={() => form.setValue("imageUrl", "")}>Remove</Button>
+                    </div>
                   )}
                 </div>
               </div>

--- a/client/pages/Store.tsx
+++ b/client/pages/Store.tsx
@@ -1,0 +1,257 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import { useEffect, useMemo, useState } from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
+
+const productSchema = z.object({
+  name: z.string().min(2, "Enter a product name"),
+  category: z.string().min(1, "Choose a category"),
+  price: z.coerce.number().min(0, "Price must be >= 0"),
+  sku: z.string().min(1, "SKU is required"),
+  stock: z.coerce.number().int().min(0, "Stock must be >= 0"),
+  imageUrl: z
+    .string()
+    .url({ message: "Must be a valid URL" })
+    .optional()
+    .or(z.literal("")),
+  description: z.string().max(500).optional().or(z.literal("")),
+});
+
+type ProductInput = z.infer<typeof productSchema>;
+
+type Product = ProductInput & {
+  id: string;
+  addedAt: string; // ISO date
+};
+
+function uid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+const CATEGORIES = ["Coffee", "Bakery", "Cold", "Merch"] as const;
+
+export default function Store() {
+  const [items, setItems] = useState<Product[]>(() => {
+    try {
+      const raw = localStorage.getItem("catalog");
+      if (!raw) return [];
+      const parsed = JSON.parse(raw) as Product[];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("catalog", JSON.stringify(items));
+    } catch {}
+  }, [items]);
+
+  const form = useForm<ProductInput>({
+    resolver: zodResolver(productSchema),
+    defaultValues: {
+      name: "",
+      category: "",
+      price: 0,
+      sku: "",
+      stock: 0,
+      imageUrl: "",
+      description: "",
+    },
+  });
+
+  const onSubmit = (values: ProductInput) => {
+    const product: Product = {
+      ...values,
+      imageUrl: values.imageUrl && values.imageUrl.trim() !== "" ? values.imageUrl : "/placeholder.svg",
+      id: uid(),
+      addedAt: new Date().toISOString(),
+    };
+    setItems((prev) => [...prev, product]);
+    toast({ title: "Product added", description: `${values.name} has been added to your catalog.` });
+    form.reset({ ...form.getValues(), name: "", price: 0, sku: "", stock: 0, description: "", imageUrl: "" });
+  };
+
+  const totalSkus = items.length;
+  const totalInventory = useMemo(() => items.reduce((s, it) => s + (Number.isFinite(it.stock) ? it.stock : 0), 0), [items]);
+
+  return (
+    <DashboardLayout title="Online Store">
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Product form */}
+        <Card className="lg:col-span-1">
+          <CardHeader>
+            <CardTitle>Add Product</CardTitle>
+            <CardDescription>Fill the form to append a product to the catalog below.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="space-y-4"
+            >
+              <div className="grid gap-3">
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" placeholder="e.g. Ground Coffee" {...form.register("name")} />
+                {form.formState.errors.name && (
+                  <p className="text-sm text-destructive">{form.formState.errors.name.message}</p>
+                )}
+              </div>
+
+              <div className="grid gap-3">
+                <Label htmlFor="category">Category</Label>
+                <Select onValueChange={(v) => form.setValue("category", v)}>
+                  <SelectTrigger id="category">
+                    <SelectValue placeholder="Select category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CATEGORIES.map((c) => (
+                      <SelectItem key={c} value={c}>{c}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {form.formState.errors.category && (
+                  <p className="text-sm text-destructive">{form.formState.errors.category.message}</p>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="grid gap-3">
+                  <Label htmlFor="price">Price ($)</Label>
+                  <Input id="price" type="number" step="0.01" min={0} {...form.register("price", { valueAsNumber: true })} />
+                  {form.formState.errors.price && (
+                    <p className="text-sm text-destructive">{form.formState.errors.price.message}</p>
+                  )}
+                </div>
+                <div className="grid gap-3">
+                  <Label htmlFor="stock">Stock</Label>
+                  <Input id="stock" type="number" min={0} {...form.register("stock", { valueAsNumber: true })} />
+                  {form.formState.errors.stock && (
+                    <p className="text-sm text-destructive">{form.formState.errors.stock.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="grid gap-3">
+                  <Label htmlFor="sku">SKU</Label>
+                  <Input id="sku" placeholder="e.g. GRND-250" {...form.register("sku")} />
+                  {form.formState.errors.sku && (
+                    <p className="text-sm text-destructive">{form.formState.errors.sku.message}</p>
+                  )}
+                </div>
+                <div className="grid gap-3">
+                  <Label htmlFor="imageUrl">Image URL</Label>
+                  <Input id="imageUrl" placeholder="https://..." {...form.register("imageUrl")} />
+                  {form.formState.errors.imageUrl && (
+                    <p className="text-sm text-destructive">{form.formState.errors.imageUrl.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid gap-3">
+                <Label htmlFor="description">Description</Label>
+                <Textarea id="description" rows={4} placeholder="Short description" {...form.register("description")} />
+              </div>
+
+              <div className="flex items-center gap-3">
+                <Button type="submit">Add to Catalog</Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => form.reset()}
+                >
+                  Reset
+                </Button>
+                {items.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setItems([])}
+                    className="ml-auto text-destructive"
+                  >
+                    Clear All
+                  </Button>
+                )}
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        {/* Catalog table */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle>Catalog</CardTitle>
+            <CardDescription>
+              {totalSkus} products • {totalInventory} total units in stock
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Product</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>SKU</TableHead>
+                  <TableHead>Price</TableHead>
+                  <TableHead>Stock</TableHead>
+                  <TableHead>Added</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((p) => (
+                  <TableRow key={p.id}>
+                    <TableCell className="flex items-center gap-3">
+                      <img src={p.imageUrl} alt="" className="size-10 rounded-md object-cover border" />
+                      <div>
+                        <div className="font-medium leading-tight">{p.name}</div>
+                        {p.description && (
+                          <div className="text-xs text-muted-foreground line-clamp-1">{p.description}</div>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>{p.category}</TableCell>
+                    <TableCell>{p.sku}</TableCell>
+                    <TableCell>${p.price.toFixed(2)}</TableCell>
+                    <TableCell>{p.stock}</TableCell>
+                    <TableCell>{new Date(p.addedAt).toLocaleDateString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <TableCaption>Newly added products appear at the bottom.</TableCaption>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/pages/Store.tsx
+++ b/client/pages/Store.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "@/hooks/use-toast";
+import { Trash2 } from "lucide-react";
 
 const productSchema = z.object({
   name: z.string().min(2, "Enter a product name"),
@@ -59,7 +60,7 @@ function uid() {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }
 
-const CATEGORIES = ["Coffee", "Bakery", "Cold", "Merch"] as const;
+const CATEGORIES = ["Coffee", "Cold"] as const;
 const UNITS = ["g", "ml", "pcs"] as const;
 const WEIGHT_SIZES = [250, 500, 750, 1000] as const;
 
@@ -233,16 +234,6 @@ export default function Store() {
                 >
                   Reset
                 </Button>
-                {items.length > 0 && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={() => setItems([])}
-                    className="ml-auto text-destructive"
-                  >
-                    Clear All
-                  </Button>
-                )}
               </div>
             </form>
           </CardContent>
@@ -267,6 +258,7 @@ export default function Store() {
                   <TableHead>Price</TableHead>
                   <TableHead>Stock</TableHead>
                   <TableHead>Added</TableHead>
+                  <TableHead className="text-right">Action</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -287,6 +279,20 @@ export default function Store() {
                     <TableCell>${p.price.toFixed(2)}</TableCell>
                     <TableCell>{p.stock}</TableCell>
                     <TableCell>{new Date(p.addedAt).toLocaleDateString()}</TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-destructive"
+                        onClick={() => {
+                          setItems((prev) => prev.filter((it) => it.id !== p.id));
+                          toast({ title: "Deleted", description: `${p.name} removed from catalog.` });
+                        }}
+                        aria-label={`Delete ${p.name}`}
+                      >
+                        <Trash2 />
+                      </Button>
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>


### PR DESCRIPTION
## Purpose

The user requested a comprehensive product catalog management system with the following requirements:
- Product size/variant specification (e.g., coffee weights: 250g, 500g, 750g, 1000g)
- Removal of bakery and merch categories, focusing on Coffee and Cold drinks
- Image upload functionality instead of URL input
- Visual image indicators in the product table
- Individual product deletion with delete icons
- Product editing capabilities with edit icons
- UI improvements to fix icon positioning bugs

## Code changes

- **New Store page**: Created complete product catalog management interface at `/client/pages/Store.tsx`
- **Routing**: Added Store route to App.tsx and navigation item to DashboardLayout
- **Product form**: Implemented form with category selection (Coffee/Cold), size variants, image upload, and all required fields
- **Product table**: Added catalog display with image indicators, edit/delete action buttons
- **Size management**: Added dynamic size selection based on category (weight sizes for coffee, standard sizes for other items)
- **Image handling**: Replaced URL input with file upload supporting drag-and-drop with 3MB limit
- **Edit functionality**: Implemented inline editing that populates form when edit icon is clicked
- **Local storage**: Added persistence for catalog data across browser sessions
- **UI components**: Used shadcn/ui components for consistent styling and responsive designTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/234d55dcb41d4596962e96f992ee1a15/spark-haven)

👀 [Preview Link](https://234d55dcb41d4596962e96f992ee1a15-spark-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>234d55dcb41d4596962e96f992ee1a15</projectId>-->
<!--<branchName>spark-haven</branchName>-->